### PR TITLE
Fix connection via JWT

### DIFF
--- a/cheshire_cat_api/cat_client.py
+++ b/cheshire_cat_api/cat_client.py
@@ -65,12 +65,11 @@ class CatClient:
         self.settings = SettingsApi(client)
         self.llm = LargeLanguageModelApi(client)
 
-    def connect_ws(self, token=None):
+    def connect_ws(self):
         protocol = "wss" if self._conn_settings.secure_connection else "ws"
-        self.token = token
         url = f"{protocol}://{self._conn_settings.base_url}:{self._conn_settings.port}/ws/{self._conn_settings.user_id}"
-        if token:
-            url += f"?token={quote(token)}"
+        if self._conn_settings.auth_key:
+            url += f"?token={self._conn_settings.auth_key}"
 
         self._ws = WebSocketApp(
             url,

--- a/cheshire_cat_api/cat_client.py
+++ b/cheshire_cat_api/cat_client.py
@@ -3,7 +3,6 @@ import logging
 from typing import Callable, Optional
 from websocket import WebSocketApp
 from threading import Thread
-from urllib.parse import quote
 from cheshire_cat_api.api_client import ApiClient
 from cheshire_cat_api.configuration import Configuration
 from cheshire_cat_api.config import Config

--- a/cheshire_cat_api/cat_client.py
+++ b/cheshire_cat_api/cat_client.py
@@ -3,6 +3,7 @@ import logging
 from typing import Callable, Optional
 from websocket import WebSocketApp
 from threading import Thread
+from urllib.parse import quote
 from cheshire_cat_api.api_client import ApiClient
 from cheshire_cat_api.configuration import Configuration
 from cheshire_cat_api.config import Config
@@ -64,9 +65,12 @@ class CatClient:
         self.settings = SettingsApi(client)
         self.llm = LargeLanguageModelApi(client)
 
-    def connect_ws(self):
+    def connect_ws(self, token=None):
         protocol = "wss" if self._conn_settings.secure_connection else "ws"
+        self.token = token
         url = f"{protocol}://{self._conn_settings.base_url}:{self._conn_settings.port}/ws/{self._conn_settings.user_id}"
+        if token:
+            url += f"?token={quote(token)}"
 
         self._ws = WebSocketApp(
             url,


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes https://github.com/cheshire-cat-ai/api-client-py/issues/14

![image](https://github.com/user-attachments/assets/0af80899-08bc-425d-a3b7-313fd79de903)

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- In **cat_client.py**,  I added the parameter `token` to method  `ws_connect`, to extend the string `url`: this way, users can connect  to the cat via custom auth handler:
```python
    def connect_ws(self):
        protocol = "wss" if self._conn_settings.secure_connection else "ws"
        url = f"{protocol}://{self._conn_settings.base_url}:{self._conn_settings.port}/ws/{self._conn_settings.user_id}"
        if self._conn_settings.auth_key:
            url += f"?token={self._conn_settings.auth_key}"
```

 This way, if argument `auth_key` is provided in `ccat.Config` , the needed string plus JWT is appended to string `url`.

Small script to test the fix:
```python
from typing import Any
import time
import json
import requests
import cheshire_cat_api as ccat

PORT = 1865
USER = "admin"
PASSWORD = "admin"


def default(l: list[Any], idx: int, default_value: Any):
    return default_value if len(l) <= idx else l[idx]


def obtain_jwt():
    print("Obtaining JWT token...")
    response = requests.post(
        "http://localhost:1865/auth/token",
        json={"username": USER, "password": PASSWORD},
    )
    if response.status_code == 200:
        jwt = response.json()["access_token"]
        print("JWT obtained successfully.")
        return jwt
    else:
        print("Failed to obtain JWT: %s", response.text)
        return None


config = ccat.Config(
    user_id=USER,
    base_url="localhost",
    port=PORT,
    auth_key=obtain_jwt(),
    secure_connection=False,
)


cat_client = ccat.CatClient(config=config)

msg = "Are we all mad here?"


def question():
    time.sleep(3)
    print("Sending question to the CatClient...")
    cat_client.send(msg)
    print("Message sent:", msg)


def message_callback(msg):
    msg_data = json.loads(msg)
    if msg_data["type"] == "chat":
        print("Cat's answer:", msg_data["content"])


cat_client.on_open = question
cat_client.on_message = message_callback


def main():
    print("Attempting to connect to the CatClient...")
    jwt = obtain_jwt()
    if jwt is None:
        return
    try:
        cat_client.connect_ws()
        print("Connected to CatClient.")
    except Exception as e:
        print("Failed to connect to CatClient: %s", e)
        return

    time.sleep(25)
    cat_client.close()
    print("CatClient closed.")


if __name__ == "__main__":
    main()
```

Without the fix, the script will result in this error:
```shell
ERROR - Handshake status 403 Forbidden -+-+- {'date': 'Mon, 03 Feb 2025 21:30:49 GMT', 'content-length': '0', 'content-type': 'text/plain', 'connection': 'close'} -+-+- b'' - goodbye
INFO - Connection with id admin closed with code None: None
```

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [X] I've read and followed all steps in the [Making a pull request](https://github.com/cheshire-cat-ai/cheshire-cat-api/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/cheshire-cat-ai/cheshire-cat-api/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
